### PR TITLE
Added fadeout to transparent tab title

### DIFF
--- a/example/renderer/style.css
+++ b/example/renderer/style.css
@@ -54,6 +54,7 @@ body {
   display: flex;
   margin: 0 5px 0 10px;
   overflow: hidden;
+  -webkit-mask-image: -webkit-gradient(linear, left top, right top, from(#000000), color-stop(80%, #000000), to(transparent));
 }
 .title-content {
   flex-shrink: 0;


### PR DESCRIPTION
Added a fadeout to transparent for the tab title similar to the one in Chrome browser:

Before:
<img width="441" alt="before" src="https://user-images.githubusercontent.com/12685981/230740623-de5a4fae-dca1-4db9-9412-42cf3efea8c1.png">

After:
<img width="458" alt="after" src="https://user-images.githubusercontent.com/12685981/230740634-18716981-888c-49d0-ae5c-0fa1ee5accd1.png">

Chrome browser as a reference:
<img width="285" alt="chrome" src="https://user-images.githubusercontent.com/12685981/230740642-e9086c02-318d-48c3-9d15-4ef3fe34c744.png">
